### PR TITLE
Making settings module public and enabling use of other config file formats

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -6,8 +6,7 @@ pub use http_request::HttpRequest;
 pub use http_response::HttpResponse;
 pub use http_route::HttpRoute;
 pub use http_server::start_http_server;
-// pub(crate) use logger::ACCESS_LOGGER;
-pub use service::{IN_ROTATION, Service, ServiceBuilder, ServiceDaemon, SHUTDOWN};
+pub use service::{Service, ServiceBuilder, ServiceDaemon, IN_ROTATION, SHUTDOWN};
 
 pub type ApiResult<R> = Result<R, ApiError>;
 pub type HttpResult = Result<Response<Body>, ApiError>;
@@ -25,6 +24,6 @@ mod http_server;
 mod service;
 
 #[cfg(feature = "settings")]
-mod settings;
+pub mod settings;
 
 pub mod utils;

--- a/src/server/service.rs
+++ b/src/server/service.rs
@@ -8,7 +8,7 @@ use hyper::Body;
 use crate::server::{ApiError, HttpRoute};
 
 lazy_static! {
-    pub static ref IN_ROTATION: AtomicBool = AtomicBool::new(true);
+    pub static ref IN_ROTATION: AtomicBool = AtomicBool::new(false);
     pub static ref SHUTDOWN: AtomicBool = AtomicBool::new(false);
 }
 

--- a/src/server/settings.rs
+++ b/src/server/settings.rs
@@ -1,5 +1,5 @@
 use anyhow::Context;
-use config::{Config, File, FileFormat};
+use config::{Config, File};
 use parking_lot::RwLock;
 
 lazy_static! {
@@ -24,13 +24,14 @@ pub fn load_global_config(base_dir: &str, env: &str) -> anyhow::Result<()> {
     let mut write_guard = settings().write();
 
     let mut builder = Config::builder();
-    let default_config_file = format!("{}/service-default.yml", base_dir);
-    builder = builder.add_source(File::new(&default_config_file, FileFormat::Yaml));
+    let default_config_file = format!("{}/service-default", base_dir);
+    builder = builder.add_source(File::with_name(&default_config_file));
 
-    let env_config_file = format!("{}/service-{}.yml", base_dir, env);
-    builder = builder.add_source(File::new(&env_config_file, FileFormat::Yaml));
+    let env_config_file = format!("{}/service-{}", base_dir, env);
+    builder = builder.add_source(File::with_name(&env_config_file));
 
-    let config = builder.build()
+    let config = builder
+        .build()
         .with_context(|| format!("Error in loading config from dir: {} for env: {}", base_dir, env))?;
 
     *write_guard = config;


### PR DESCRIPTION
- Expose settings module (the functionality is not accessible without it)
- Remove config file format constraint